### PR TITLE
修改生产者-消费者代码示例

### DIFF
--- a/docs/golang/core/concurrent/concurrent-model.md
+++ b/docs/golang/core/concurrent/concurrent-model.md
@@ -289,7 +289,6 @@ func producer(id int, jobs chan<- int, wg *sync.WaitGroup) {
 
 // 消费者函数从通道接收数据并处理
 func consumer(id int, jobs <-chan int, wg *sync.WaitGroup) {
-    defer wg.Done()
     for j := range jobs {
         fmt.Printf("Consumer %d processing job %d\n", id, j)
         time.Sleep(time.Second)
@@ -308,7 +307,6 @@ func main() {
 
     // 启动消费者 Goroutine
     for c := 1; c <= 2; c++ {
-        wg.Add(1)
         go consumer(c, jobs, &wg)
     }
 


### PR DESCRIPTION
修改了生产者-消费者模型代码示例：main函数创建consumers循环中的wg.Add(1)删除；consumer函数中的defer部分删除。原示例会造成死锁（main等待所有goroutine结束，而consumer goroutine需要close channel才能结束）望repo owner检查。

![image](https://github.com/user-attachments/assets/490b62bb-5e9a-4309-8e66-ddb035959255)
